### PR TITLE
Removing usage of word Sapphire from code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,5 @@ Session.vim
 /.config/gcloud*/
 /.gsutil/
 
-# Sapphire stub files
+# Amino Run stub files
 **/stubs/**

--- a/chess/src/main/java/engine/SimpleEngine.java
+++ b/chess/src/main/java/engine/SimpleEngine.java
@@ -32,7 +32,7 @@ public class SimpleEngine implements ChessEngine, MicroService, ExplicitMigrator
 	private boolean computerIsWhite;
 	private int ply;
 
-	// Moved the following members to private as Sapphire Object does not allow to have public member variables
+	// Moved the following members to private as microservice does not allow to have public member variables
 	//public final static int MATE = 50000;
 	//public final static int INF = 100000;
 	private final static int MATE = 50000;

--- a/hanksTodo/src/main/java/amino/run/appexamples/hankstodo/device/TodoActivity.java
+++ b/hanksTodo/src/main/java/amino/run/appexamples/hankstodo/device/TodoActivity.java
@@ -46,7 +46,7 @@ public class TodoActivity {
 		TodoList tl = null;
 		try {
 			tl = tlm.newTodoList(id);
-			// Consensus policy needs some time after creating new Sapphire object; otherwise,
+			// Consensus policy needs some time after creating new microservice; otherwise,
 			// leader election may fail.
 			sleep(7000);
 		} catch (Exception e) {

--- a/k8s-deployment/common/start-kernelserver.sh
+++ b/k8s-deployment/common/start-kernelserver.sh
@@ -26,4 +26,4 @@ if [ -z $OMS_IP ]; then
 fi
 
 echo "Starting KernelServer on $KERNELSERVER_IP:$KERNELSERVER_PORT, connecting to $OMS_SERVICE at $OMS_IP:$OMS_PORT .."
-java -cp "/root/dcap/jars/*" -Djava.rmi.server.useCodebaseOnly=false -Djava.security.policy=/dcap/client.policy sapphire.kernel.server.KernelServerImpl $KERNELSERVER_IP $KERNELSERVER_PORT $OMS_IP $OMS_PORT
+java -cp "/root/dcap/jars/*" -Djava.rmi.server.useCodebaseOnly=false -Djava.security.policy=/dcap/client.policy amino.run.kernel.server.KernelServerImpl $KERNELSERVER_IP $KERNELSERVER_PORT $OMS_IP $OMS_PORT

--- a/k8s-deployment/common/start-oms.sh
+++ b/k8s-deployment/common/start-oms.sh
@@ -18,4 +18,4 @@ if [ -z $OMS_IP ]; then
 fi
 
 echo "Starting OMS for app $OMS_APP_MAIN_CLASS, listening on $OMS_IP:$OMS_PORT .."
-java -cp "/root/dcap/jars/*" sapphire.oms.OMSServerImpl $OMS_IP $OMS_PORT $OMS_APP_MAIN_CLASS
+java -cp "/root/dcap/jars/*" amino.run.oms.OMSServerImpl $OMS_IP $OMS_PORT $OMS_APP_MAIN_CLASS

--- a/minnieTwitter/minnietwitter-app.yml
+++ b/minnieTwitter/minnietwitter-app.yml
@@ -20,5 +20,5 @@ spec:
         ports:
         - containerPort: 22345
         command: ["/root/dcap/start-app.sh"]
-        args: ["sapphire.appexamples.minnietwitter.device.generator.TwitterWorldGenerator", "oms-minnietwitter-svc", "22346"]
+        args: ["amino.run.appexamples.minnietwitter.device.generator.TwitterWorldGenerator", "oms-minnietwitter-svc", "22346"]
 

--- a/minnieTwitter/src/main/java/amino/run/appexamples/minnietwitter/device/TwitterActivityOne.java
+++ b/minnieTwitter/src/main/java/amino/run/appexamples/minnietwitter/device/TwitterActivityOne.java
@@ -44,7 +44,7 @@ public class TwitterActivityOne {
         Registry server = (Registry) registry.lookup("io.amino.run.oms");
 
         // This kernel server is a fake kernel server. It is _not_ registered in OMS. Therefore
-        // there will be no Sapphire object on this server. The purpose of creating such a fake
+        // there will be no microservice on this server. The purpose of creating such a fake
         // kernel server is to construct a KernelClient (inside the KernelServer object) and to
         // configure GlobalKernelReferences.nodeServer properly.
         //

--- a/minnieTwitter/src/main/java/amino/run/appexamples/minnietwitter/device/TwitterActivityTwo.java
+++ b/minnieTwitter/src/main/java/amino/run/appexamples/minnietwitter/device/TwitterActivityTwo.java
@@ -38,7 +38,7 @@ public class TwitterActivityTwo {
         Registry server = (Registry) registry.lookup("io.amino.run.oms");
 
         // This kernel server is a fake kernel server. It is _not_ registered in OMS. Therefore
-        // there will be no Sapphire object on this server. The purpose of creating such a fake
+        // there will be no microservice on this server. The purpose of creating such a fake
         // kernel server is to construct a KernelClient (inside the KernelServer object) and to
         // configure GlobalKernelReferences.nodeServer properly.
         //

--- a/minnieTwitter/src/main/java/amino/run/appexamples/minnietwitter/device/generator/TwitterWorldGenerator.java
+++ b/minnieTwitter/src/main/java/amino/run/appexamples/minnietwitter/device/generator/TwitterWorldGenerator.java
@@ -43,18 +43,18 @@ public class TwitterWorldGenerator {
 			MicroServiceID microServiceId = server.create(spec.toString());
 			TwitterManager tm = (TwitterManager) server.acquireStub(microServiceId);
 
-			/* To set a name to sapphire object. It is required to set the name if the object has to be shared */
+			/* To set a name to microservice. It is required to set the name if the object has to be shared */
 			server.setName(microServiceId, "MyTwitterManager");
 
-                        /* Attach to sapphire object is to get reference to shared sapphire object. Generally it
-                        is not done in the same thread which creates sapphire object. In this example,
-                        Twitter manager sapphire object is created just above in same thread. Below attach call
+                        /* Attach to microservice is to get reference to shared microservice. Generally it
+                        is not done in the same thread which creates microservice. In this example,
+                        Twitter manager microservice is created just above in same thread. Below attach call
                         has no significance. It is just used to show the usage of API. */
 			TwitterManager tmAttached =
 					(TwitterManager) server.attachTo("MyTwitterManager");
 
-                        /* Detach from the shared sapphire object. It is necessary to explicitly call detach to
-                        un-reference the sapphire object. This call is not required here if attach call was not
+                        /* Detach from the shared microservice. It is necessary to explicitly call detach to
+                        un-reference the microservice. This call is not required here if attach call was not
                         made above */
 			server.detachFrom("MyTwitterManager");
 

--- a/minnieTwitter/src/main/res/layout/activity_home.xml
+++ b/minnieTwitter/src/main/res/layout/activity_home.xml
@@ -7,7 +7,7 @@
     android:paddingLeft="15dp"
     android:paddingRight="15dp"
     android:paddingTop="15dp"
-    tools:context="sapphire.appexamples.minnietwitter.glue.HomeActivity">
+    tools:context="amino.run.appexamples.minnietwitter.glue.HomeActivity">
 
     <EditText
         android:id="@+id/tweetBody"

--- a/minnieTwitter/src/main/res/layout/show_tweets.xml
+++ b/minnieTwitter/src/main/res/layout/show_tweets.xml
@@ -8,7 +8,7 @@
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
     android:background="@drawable/bg_card"
-    tools:context="sapphire.appexamples.minnietwitter.glue.MyTweets" >
+    tools:context="amino.run.appexamples.minnietwitter.glue.MyTweets" >
 
     <ListView
         android:id="@+id/list"


### PR DESCRIPTION
Fixes #82 

Removed leftover usage of the word sapphire from the code and docs in the examples repo.